### PR TITLE
chore(ci): implement actionlint for GitHub Actions workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,21 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run actionlint
+      uses: rhysd/actionlint@v1.7.10

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -30,10 +30,10 @@ jobs:
 
     - name: Get Composer cache directory
       id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload PHAR to release
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           build/oce-import-codes.phar

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
     - --indent=2
     exclude: ^compose\.yml$  # Uses Docker Compose !override tags
 
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.10
+  hooks:
+  - id: actionlint
+
 - repo: local
   hooks:
   - id: php-syntax-check


### PR DESCRIPTION
## Summary

- Add actionlint to validate GitHub Actions workflow files
- Add pre-commit hook and CI workflow for automated linting
- Fix existing issues found in build-phar.yml

Fixes #11

## Test plan

- [x] Verify actionlint pre-commit hook runs on workflow file changes
- [x] Verify actionlint CI workflow passes

🤖 Generated with [Claude Code](https://claude.ai/code)