### PR TITLE
feat(import): add --allow-unsupported flag and improve staging cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,15 @@ task dev:port
 ### Running the CLI
 
 ```bash
-# Copy a code file into the container and run
+# Files in .local/vocabs/ are accessible inside the container
+task cli:run -- /var/www/localhost/htdocs/openemr/oce-cli-import-codes/.local/vocabs/codes.zip
+
+# Or copy a file into the container first
 docker cp /local/path/to/RxNorm.zip $(docker compose ps -q openemr):/tmp/
 task cli:run -- /tmp/RxNorm.zip
 
 # Or run directly via docker compose exec
-docker compose exec openemr php /var/www/localhost/htdocs/openemr/oce-cli-import-codes/bin/oce-import-codes import /tmp/codes.zip
+docker compose exec openemr php /var/www/localhost/htdocs/openemr/oce-cli-import-codes/bin/oce-import-codes /tmp/codes.zip
 ```
 
 ## Code Quality
@@ -150,15 +153,59 @@ task db:query -- "SELECT * FROM standardized_tables_track"
 ## CLI Options
 
 ```
---openemr-path    Path to OpenEMR installation (default: /var/www/localhost/htdocs/openemr)
---site            OpenEMR site name (default: default)
---code-type       Override auto-detected code type
---dry-run         Test without database changes
---cleanup         Remove temp files after import
---force           Import even if same version already loaded
---lock-retry-attempts   Retry count for database lock (default: 10)
---lock-retry-delay      Initial retry delay in seconds (default: 30)
+--openemr-path        Path to OpenEMR installation (default: /var/www/localhost/htdocs/openemr)
+--site                OpenEMR site name (default: default)
+--code-type           Override auto-detected code type
+--dry-run             Test without database changes
+--cleanup/--no-cleanup  Clean staging directory after import (default: --cleanup)
+--force               Import even if same version already loaded
+--allow-unsupported   Required for files not in supported_external_dataloads table
+--lock-retry-attempts Retry count for database lock (default: 10)
+--lock-retry-delay    Initial retry delay in seconds (default: 30)
 ```
+
+### Staging Directory Cleanup
+
+By default, the CLI cleans the staging directory (`/tmp/{CODE_TYPE}/`) after each import. This prevents duplicate imports when running multiple times.
+
+- **Default behavior**: Staging directory is cleaned after successful import
+- **`--no-cleanup`**: Keep staging files for debugging (warning issued about duplicate risk)
+- **Startup warning**: If existing files are found in staging before import, a warning is logged
+
+To manually clean staging directories:
+
+```bash
+task db:clean-vocabs -- ICD10   # Clean specific vocab type
+task db:clean-vocabs            # Clean all vocab types
+```
+
+### Importing Unsupported Code Versions
+
+OpenEMR validates code files by checking the filename and MD5 checksum against the `supported_external_dataloads` table. This table ships with each OpenEMR release and only contains entries for code versions known at release time.
+
+**By default, the CLI will reject files not in this table.** To import newer codes (e.g., 2026 ICD codes on an OpenEMR version that only knows about 2025), use the `--allow-unsupported` flag:
+
+```bash
+task cli:run -- /path/to/icd10orderfiles.zip --allow-unsupported
+```
+
+**How it works:**
+
+1. Checks the `supported_external_dataloads` table for filename + checksum match
+2. If not found, fails with an error (unless `--allow-unsupported` is set)
+3. With `--allow-unsupported`, parses metadata from the filename instead
+4. Extracts the year from filename patterns and calculates the release date
+
+**Supported filename patterns:**
+
+| Pattern | Example | Detected As |
+|---------|---------|-------------|
+| `icd10OrderFiles{YEAR}` | `icd10OrderFiles2025_0.zip` | ICD10 CM, effective {YEAR-1}-10-01 |
+| `icd10cm_order_{YEAR}` | `icd10cm_order_2024.txt.zip` | ICD10 CM, effective {YEAR-1}-10-01 |
+| `*{YEAR}*ICD-10-PCS*` | `Zip File 3 2026 ICD-10-PCS Codes File.zip` | ICD10 PCS, effective {YEAR-1}-10-01 |
+| `icd10orderfiles.zip` | (no year) | ICD10 CM, uses current fiscal year |
+
+ICD codes become effective October 1st, so "2026 codes" have release date 2025-10-01.
 
 ## Troubleshooting
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -131,17 +131,17 @@ tasks:
   cli:run:
     desc: 'Run the import codes CLI (usage: task cli:run -- /path/to/file.zip)'
     cmds:
-    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes import --openemr-path={{.OPENEMR_PATH}} {{.CLI_ARGS}}
+    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes --openemr-path={{.OPENEMR_PATH}} {{.CLI_ARGS}}
 
   cli:help:
     desc: Show CLI help
     cmds:
-    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes import --help
+    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes --help
 
   cli:dry-run:
     desc: 'Run CLI in dry-run mode (usage: task cli:dry-run -- /path/to/file.zip)'
     cmds:
-    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes import --openemr-path={{.OPENEMR_PATH}} --dry-run {{.CLI_ARGS}}
+    - docker compose exec openemr php {{.CLI_PATH}}/bin/oce-import-codes --openemr-path={{.OPENEMR_PATH}} --dry-run {{.CLI_ARGS}}
 
   # === Database Access ===
 
@@ -172,18 +172,78 @@ tasks:
     desc: Show loaded code types and counts
     cmds:
     - |
-      docker compose exec mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -e "
-      SELECT 'RXNORM' as code_type, COUNT(*) as count FROM rxnconso
-      UNION ALL SELECT 'SNOMED', COUNT(*) FROM sct_descriptions
-      UNION ALL SELECT 'ICD10', COUNT(*) FROM icd10_dx_order_code
-      UNION ALL SELECT 'ICD9', COUNT(*) FROM icd9_dx_code
-      UNION ALL SELECT 'CQM_VALUESET', COUNT(*) FROM valueset
-      " {{.DB_NAME}} 2>&1 | grep -v "Using a password"
+      echo "code_type	count"
+      echo "---------	-----"
+      for pair in "RXNORM:rxnconso" "SNOMED:sct_descriptions" "ICD10:icd10_dx_order_code" "ICD9:icd9_dx_code" "CQM_VALUESET:valueset"; do
+        name="${pair%%:*}"
+        table="${pair##*:}"
+        count=$(docker compose exec -T mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -N -e "SELECT COUNT(*) FROM $table" {{.DB_NAME}} 2>/dev/null | grep -v "Using a password" || echo "0")
+        echo "$name	$count"
+      done
 
   db:tracking:
     desc: Show standardized tables tracking info
     cmds:
-    - docker compose exec mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -e "SELECT * FROM standardized_tables_track ORDER BY imported_date DESC" {{.DB_NAME}} 2>&1 | grep -v "Using a password"
+    - |
+      result=$(docker compose exec -T mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -e "SELECT * FROM standardized_tables_track ORDER BY imported_date DESC" {{.DB_NAME}} 2>&1 | { grep -v "Using a password" || true; })
+      if [ -z "$result" ]; then
+        echo "No vocabularies tracked yet."
+      else
+        echo "$result"
+      fi
+
+  db:clean-vocabs:
+    desc: 'Clean vocabulary tables and staging dirs (usage: task db:clean-vocabs -- ICD10 or task db:clean-vocabs for all)'
+    cmds:
+    - |
+      VOCAB="{{.CLI_ARGS}}"
+      # OpenEMR's temporary_files_dir is /tmp by default (check globals table)
+      TEMP_DIR="/tmp"
+      truncate_tables() {
+        local tables="$1"
+        for t in $tables; do
+          docker compose exec -T mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -e "TRUNCATE TABLE $t" {{.DB_NAME}} 2>/dev/null || true
+        done
+      }
+      clean_tracking() {
+        local name="$1"
+        docker compose exec -T mysql mariadb -u{{.DB_USER}} -p{{.DB_PASS}} -e "DELETE FROM standardized_tables_track WHERE name = '$name'" {{.DB_NAME}} 2>/dev/null
+      }
+      clean_staging() {
+        local dir="$1"
+        docker compose exec -T openemr rm -rf "$TEMP_DIR/$dir" 2>/dev/null || true
+      }
+      if [ -z "$VOCAB" ] || [ "$VOCAB" = "RXNORM" ]; then
+        echo "Cleaning RXNORM..."
+        truncate_tables "rxnconso rxnrel rxnatomarchive rxncui rxnsat rxnsty"
+        clean_tracking "RXNORM"
+        clean_staging "RXNORM"
+      fi
+      if [ -z "$VOCAB" ] || [ "$VOCAB" = "SNOMED" ]; then
+        echo "Cleaning SNOMED..."
+        truncate_tables "sct_descriptions sct_concepts sct_relationships"
+        clean_tracking "SNOMED"
+        clean_staging "SNOMED"
+      fi
+      if [ -z "$VOCAB" ] || [ "$VOCAB" = "ICD10" ]; then
+        echo "Cleaning ICD10..."
+        truncate_tables "icd10_dx_order_code icd10_pcs_order_code icd10_gem_dx_10_9 icd10_gem_dx_9_10 icd10_gem_pcs_10_9 icd10_gem_pcs_9_10 icd10_reimbr_dx_9_10 icd10_reimbr_pcs_9_10"
+        clean_tracking "ICD10"
+        clean_staging "ICD10"
+      fi
+      if [ -z "$VOCAB" ] || [ "$VOCAB" = "ICD9" ]; then
+        echo "Cleaning ICD9..."
+        truncate_tables "icd9_dx_code icd9_dx_long_code icd9_sg_code icd9_sg_long_code"
+        clean_tracking "ICD9"
+        clean_staging "ICD9"
+      fi
+      if [ -z "$VOCAB" ] || [ "$VOCAB" = "CQM_VALUESET" ]; then
+        echo "Cleaning CQM_VALUESET..."
+        truncate_tables "valueset"
+        clean_tracking "CQM_VALUESET"
+        clean_staging "CQM_VALUESET"
+      fi
+      echo "Done."
 
   # === Code Quality (delegates to Composer scripts) ===
   # These tasks call Composer scripts directly on the host (no Docker needed).

--- a/src/Command/ImportCodesCommand.php
+++ b/src/Command/ImportCodesCommand.php
@@ -68,7 +68,12 @@ class ImportCodesCommand extends Command
             ->addOption('site', null, InputOption::VALUE_REQUIRED, 'Name of OpenEMR site', 'default')
             ->addOption('windows', 'w', InputOption::VALUE_NONE, 'Use Windows-specific processing (RXNORM only)')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Perform a dry run without making database changes')
-            ->addOption('cleanup', null, InputOption::VALUE_NONE, 'Clean up temporary files after import')
+            ->addOption(
+                'cleanup',
+                null,
+                InputOption::VALUE_NEGATABLE,
+                'Clean staging directory after import (default: true, use --no-cleanup to disable)'
+            )
             ->addOption('temp-dir', null, InputOption::VALUE_REQUIRED, 'Custom temporary directory path')
             ->addOption(
                 'force',
@@ -90,6 +95,12 @@ class ImportCodesCommand extends Command
                 'Delay between lock retries in seconds (default: 30, 0 for no retries)',
                 30
             )
+            ->addOption(
+                'allow-unsupported',
+                null,
+                InputOption::VALUE_NONE,
+                'Allow importing code files not in supported_external_dataloads table'
+            )
             ->addUsage('/path/to/RxNorm_full_01012024.zip --openemr-path=/var/www/openemr')
             ->addUsage('/path/to/SnomedCT_USEditionRF2_PRODUCTION_20240301T120000Z.zip')
             ->addUsage('/path/to/icd10cm_order_2024.txt.zip --cleanup');
@@ -109,8 +120,9 @@ class ImportCodesCommand extends Command
         $isWindows = $input->getOption('windows');
         /** @var bool $dryRun */
         $dryRun = $input->getOption('dry-run');
-        /** @var bool $cleanup */
-        $cleanup = $input->getOption('cleanup');
+        /** @var ?bool $cleanupOpt */
+        $cleanupOpt = $input->getOption('cleanup');
+        $cleanup = $cleanupOpt ?? true; // Default to true if not specified
         /** @var string|null $tempDir */
         $tempDir = $input->getOption('temp-dir');
         /** @var bool $force */
@@ -176,7 +188,9 @@ class ImportCodesCommand extends Command
         }
 
         // Auto-detect metadata from filename
-        $metadata = $this->detector->detectFromFile($filePath, $codeType);
+        /** @var bool $allowUnsupported */
+        $allowUnsupported = $input->getOption('allow-unsupported');
+        $metadata = $this->detector->detectFromFile($filePath, $codeType, $allowUnsupported);
         $usExtension = (bool) ($metadata['us_extension'] ?? false);
 
         // Log configuration with detected metadata
@@ -209,8 +223,16 @@ class ImportCodesCommand extends Command
             $this->logJson('warning', 'DRY RUN MODE - No database changes will be made');
         }
 
-        if (!$metadata['supported']) {
-            $this->logJson('warning', 'File metadata could not be fully detected - tracking may be incomplete');
+        if (!$metadata['from_database']) {
+            if (!$allowUnsupported) {
+                $this->logJson('error', 'File not in supported_external_dataloads table', [
+                    'filename' => basename($filePath),
+                    'code_type' => $codeType,
+                    'suggestion' => 'Use --allow-unsupported to bypass this check'
+                ]);
+                return Command::FAILURE;
+            }
+            $this->logJson('warning', 'File not in supported_external_dataloads - using filename-based metadata');
         }
 
         // Set custom temp directory if provided
@@ -247,6 +269,20 @@ class ImportCodesCommand extends Command
                     'suggestion' => 'Use --force flag to import anyway, or --dry-run to test without checking'
                 ]);
                 return Command::SUCCESS;
+            }
+        }
+
+        // Check for existing files in staging directory (potential for duplicates)
+        if (!$dryRun) {
+            $existingFiles = $this->importer->getStagingFiles($codeType);
+            if ($existingFiles !== []) {
+                $this->logJson('warning', 'Staging directory already contains files', [
+                    'staging_dir' => $codeType,
+                    'file_count' => count($existingFiles),
+                    'files' => array_slice($existingFiles, 0, 10), // Show first 10
+                    'risk' => 'These files may be imported along with your new file, causing duplicates',
+                    'suggestion' => 'Run "task db:clean-vocabs -- ' . $codeType . '" to clean staging first'
+                ]);
             }
         }
 
@@ -309,11 +345,16 @@ class ImportCodesCommand extends Command
                 }
             }
 
-            // Step 4: Cleanup
+            // Step 4: Cleanup (default behavior to prevent duplicate imports)
             if ($cleanup && !$dryRun) {
-                $this->logJson('info', 'Starting cleanup');
+                $this->logJson('info', 'Cleaning up staging directory');
                 $this->importer->cleanup($codeType);
-                $this->logJson('info', 'Temporary files cleaned up');
+                $this->logJson('info', 'Staging directory cleaned');
+            } elseif (!$cleanup && !$dryRun) {
+                $this->logJson(
+                    'warning',
+                    'Staging files kept (--no-cleanup). Clean before next import to avoid duplicates.'
+                );
             }
 
             $this->logJson('success', 'Import completed successfully');

--- a/src/Service/CodeImporter.php
+++ b/src/Service/CodeImporter.php
@@ -274,6 +274,38 @@ class CodeImporter
     }
 
     /**
+     * Check if staging directory exists and contains files
+     *
+     * @return list<string> List of files found in staging directory
+     */
+    public function getStagingFiles(string $type): array
+    {
+        if (!isset($GLOBALS['temporary_files_dir']) || !is_string($GLOBALS['temporary_files_dir'])) {
+            return [];
+        }
+
+        $stagingDir = $GLOBALS['temporary_files_dir'] . '/' . $type;
+        if (!is_dir($stagingDir)) {
+            return [];
+        }
+
+        $files = [];
+        $handle = opendir($stagingDir);
+        if ($handle === false) {
+            return [];
+        }
+
+        while (($file = readdir($handle)) !== false) {
+            if ($file !== '.' && $file !== '..') {
+                $files[] = $file;
+            }
+        }
+        closedir($handle);
+
+        return $files;
+    }
+
+    /**
      * Acquire a database lock for the given code type to prevent concurrent imports
      */
     private function acquireLock(string $codeType): void

--- a/src/Service/MetadataDetector.php
+++ b/src/Service/MetadataDetector.php
@@ -20,10 +20,11 @@ class MetadataDetector
      *
      * @return array<string, mixed>
      */
-    public function detectFromFile(string $filePath, string $codeType): array
+    public function detectFromFile(string $filePath, string $codeType, bool $allowUnsupported = false): array
     {
         $result = [
             'supported' => false,
+            'from_database' => false,
             'code_type' => $codeType,
             'version' => '',
             'revision_date' => '',
@@ -33,15 +34,17 @@ class MetadataDetector
         ];
 
         // Run detection directly on the filename without temp file operations
-        $revisions = $this->runOpenEMRDetection($codeType, $filePath);
+        $revisions = $this->runOpenEMRDetection($codeType, $filePath, $allowUnsupported);
 
         if ($revisions !== []) {
             $latest = end($revisions); // Get most recent
             $result['supported'] = true;
-            $result['version'] = $latest['version'];
+            $result['from_database'] = !empty($latest['from_database']);
+            $version = is_string($latest['version']) ? $latest['version'] : '';
+            $result['version'] = $version;
             $result['revision_date'] = $latest['date'];
             $result['rf2'] = isset($latest['rf2']) && $latest['rf2'];
-            $result['us_extension'] = str_contains((string) $latest['version'], 'US');
+            $result['us_extension'] = str_contains($version, 'US');
         }
 
         return $result;
@@ -49,8 +52,10 @@ class MetadataDetector
 
     /**
      * Run OpenEMR's exact detection logic (extracted from list_staged.php)
+     *
+     * @return list<array<string, mixed>>
      */
-    private function runOpenEMRDetection(string $db, string $filePath): array
+    private function runOpenEMRDetection(string $db, string $filePath, bool $allowUnsupported = false): array
     {
         $revisions = [];
         $fileName = basename($filePath);
@@ -116,29 +121,120 @@ class MetadataDetector
                 $revisions[] = ['date' => $date_release, 'version' => $version, 'path' => $filePath];
             }
         } elseif (is_numeric(strpos($db, "ICD"))) {
-            // For ICD, use database lookup if available
-            if (function_exists('sqlQuery')) {
-                $qry_str = "SELECT `load_checksum`, `load_source`, `load_release_date` "
-                    . "FROM `supported_external_dataloads` "
-                    . "WHERE `load_type` = ? AND `load_filename` = ? AND `load_checksum` = ? "
-                    . "ORDER BY `load_release_date` DESC";
-                $file_checksum = md5_file($filePath);
-                $sqlReturn = sqlQuery($qry_str, [$db, $fileName, $file_checksum]);
+            $revisions = $this->detectIcdFromFile($db, $filePath, $allowUnsupported);
+        }
 
-                if (!empty($sqlReturn)) {
-                    $version = $sqlReturn['load_source'];
-                    $date_release = $sqlReturn['load_release_date'];
-                    $revisions[] = [
-                        'date' => $date_release,
-                        'version' => $version,
-                        'path' => $filePath,
-                        'checksum' => $file_checksum
-                    ];
-                }
+        return $revisions;
+    }
+
+    /**
+     * Detect ICD metadata from file, with optional fallback to filename parsing
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function detectIcdFromFile(string $db, string $filePath, bool $allowUnsupported): array
+    {
+        $revisions = [];
+        $fileName = basename($filePath);
+        $file_checksum = md5_file($filePath);
+
+        // First try database lookup if available
+        if (function_exists('sqlQuery')) {
+            $qry_str = "SELECT `load_checksum`, `load_source`, `load_release_date` "
+                . "FROM `supported_external_dataloads` "
+                . "WHERE `load_type` = ? AND `load_filename` = ? AND `load_checksum` = ? "
+                . "ORDER BY `load_release_date` DESC";
+            $sqlReturn = sqlQuery($qry_str, [$db, $fileName, $file_checksum]);
+
+            if (!empty($sqlReturn)) {
+                return [[
+                    'date' => $sqlReturn['load_release_date'],
+                    'version' => $sqlReturn['load_source'],
+                    'path' => $filePath,
+                    'checksum' => $file_checksum,
+                    'from_database' => true
+                ]];
+            }
+        }
+
+        // If allowUnsupported, fall back to filename-based detection
+        if ($allowUnsupported) {
+            $metadata = $this->parseIcdFilename($fileName);
+            if ($metadata !== null) {
+                $revisions[] = [
+                    'date' => $metadata['release_date'],
+                    'version' => $metadata['version'],
+                    'path' => $filePath,
+                    'checksum' => $file_checksum,
+                    'from_database' => false
+                ];
             }
         }
 
         return $revisions;
+    }
+
+    /**
+     * Parse ICD metadata from filename
+     *
+     * @return ?array{release_date: string, version: string, year: int}
+     */
+    private function parseIcdFilename(string $fileName): ?array
+    {
+        // Patterns for ICD filenames with year extraction
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $patterns = [
+            // icd10OrderFiles2025_0.zip -> year 2025, effective 2024-10-01
+            '/icd10OrderFiles(\d{4})/' => 'ICD10 CM',
+            // icd10cm_order_2024.txt.zip -> year 2024, effective 2023-10-01
+            '/icd10cm_order_(\d{4})/' => 'ICD10 CM',
+            // Zip File 3 2026 ICD-10-PCS Codes File.zip -> year 2026, effective 2025-10-01
+            '/Zip File \d+ (\d{4}) ICD-10-PCS/i' => 'ICD10 PCS',
+            // zip-file-3-2026-icd-10-pcs-codes-file.zip -> year 2026, effective 2025-10-01
+            '/zip-file-\d+-(\d{4})-icd-10-pcs/i' => 'ICD10 PCS',
+            // icd9cm_order_*.zip patterns
+            '/icd9cm.*(\d{4})/' => 'ICD9 CM',
+            '/ICD-9-CM-v(\d+)/' => 'ICD9 CM',
+        ];
+        // phpcs:enable
+
+        foreach ($patterns as $pattern => $version) {
+            if (preg_match($pattern, $fileName, $matches)) {
+                $year = (int) $matches[1];
+
+                // ICD codes are effective October 1 of the previous year
+                // e.g., "2026 codes" are effective 2025-10-01
+                $effectiveYear = $year - 1;
+                $releaseDate = sprintf('%d-10-01', $effectiveYear);
+
+                return [
+                    'release_date' => $releaseDate,
+                    'version' => $version,
+                    'year' => $year
+                ];
+            }
+        }
+
+        // Handle generic icd10orderfiles.zip without year - use current fiscal year
+        if (preg_match('/icd10orderfiles\.zip$/i', $fileName)) {
+            // ICD fiscal year starts October 1
+            // If we're before October, we're in the previous fiscal year
+            $now = new \DateTime();
+            $month = (int) $now->format('n');
+            $year = (int) $now->format('Y');
+
+            // Fiscal year: Oct 2025 - Sep 2026 = FY 2026
+            $fiscalYear = $month >= 10 ? $year + 1 : $year;
+            $effectiveYear = $fiscalYear - 1;
+
+            return [
+                'release_date' => sprintf('%d-10-01', $effectiveYear),
+                'version' => 'ICD10 CM',
+                'year' => $fiscalYear
+            ];
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `--allow-unsupported` flag to import vocab files not in `supported_external_dataloads` table
- Make `--cleanup` default to true to prevent duplicate imports from leftover staging files
- Add startup warnings about existing staging files

## Changes

### `--allow-unsupported` flag
- Required for importing newer vocab versions (e.g., 2026 ICD10 on older OpenEMR)
- Without flag, import fails with helpful error message
- With flag, falls back to filename-based metadata detection
- Closes #17

### Staging directory cleanup
- `--cleanup` now defaults to true (use `--no-cleanup` to disable)
- Prevents duplicate imports - OpenEMR imports ALL files in staging dir, not just the specified file
- Startup warning if staging directory contains existing files
- Fixed `db:clean-vocabs` to use correct path (`/tmp`, not `documents/temp`)

### Other
- Added `CodeImporter::getStagingFiles()` to check for existing staged files
- Track metadata source with `from_database` flag in MetadataDetector
- Updated documentation

## Test plan

- [x] Import supported file without flag - should succeed
- [x] Import unsupported file without flag - should fail with error
- [x] Import unsupported file with `--allow-unsupported` - should succeed with warning
- [ ] Run import twice without cleanup - verify warning about existing files
- [ ] Run import with default cleanup - verify staging dir is cleaned
- [ ] Run `db:clean-vocabs` - verify `/tmp/{TYPE}` is cleaned

🤖 Generated with [Claude Code](https://claude.ai/code)