### PR TITLE
fix(ci): chain build-phar workflow from release-please

### DIFF
--- a/.github/workflows/build-phar-on-release.yml
+++ b/.github/workflows/build-phar-on-release.yml
@@ -1,0 +1,11 @@
+name: Build PHAR on Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-phar:
+    uses: ./.github/workflows/build-phar.yml
+    with:
+      tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -3,10 +3,20 @@ name: Build PHAR
 on:
   # Manual trigger
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag to attach PHAR to, e.g. v0.1.0 (leave empty for artifact only)
+        required: false
+        type: string
 
-  # Trigger when a release is created
-  release:
-    types: [created]
+  # Called by release-please workflow after release creation
+  # (release events from GITHUB_TOKEN don't trigger other workflows)
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Git tag to attach PHAR to (e.g., v0.1.0)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,6 +29,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.tag_name || github.ref }}
+        fetch-tags: true
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -44,6 +57,8 @@ jobs:
 
     - name: Build PHAR
       run: php build.php
+      env:
+        BUILD_VERSION: ${{ inputs.tag_name }}
 
     - name: Test PHAR
       run: |
@@ -51,21 +66,22 @@ jobs:
         ./build/oce-import-codes.phar --help
 
     - name: Create versioned PHAR
-      if: github.event_name == 'release'
+      if: inputs.tag_name
       run: |
-        VERSION=${{ github.event.release.tag_name }}
+        VERSION=${{ inputs.tag_name }}
         cp build/oce-import-codes.phar build/oce-import-codes-${VERSION}.phar
 
     - name: Upload PHAR to release
-      if: github.event_name == 'release'
+      if: inputs.tag_name
       uses: softprops/action-gh-release@v2
       with:
+        tag_name: ${{ inputs.tag_name }}
         files: |
           build/oce-import-codes.phar
-          build/oce-import-codes-${{ github.event.release.tag_name }}.phar
+          build/oce-import-codes-${{ inputs.tag_name }}.phar
 
     - name: Upload PHAR artifact (manual trigger)
-      if: github.event_name == 'workflow_dispatch'
+      if: ${{ !inputs.tag_name }}
       uses: actions/upload-artifact@v4
       with:
         name: oce-import-codes-phar

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -60,3 +63,13 @@ jobs:
         TAG_NAME="${{ steps.release.outputs.tag_name }}"
         git tag -a -f -m "Release ${TAG_NAME}" "${TAG_NAME}" "${TAG_NAME}^{commit}"
         git push -f origin "${TAG_NAME}"
+
+  # Build and attach PHAR to release
+  # This is called directly because release events from GITHUB_TOKEN
+  # don't trigger other workflows (GitHub security feature)
+  build-phar:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/build-phar.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}

--- a/build.php
+++ b/build.php
@@ -27,7 +27,13 @@ if (ini_get('phar.readonly')) {
 $buildDir = __DIR__ . '/build';
 $pharFile = $buildDir . '/oce-import-codes.phar';
 
-echo "Building oce-import-codes.phar...\n";
+// Determine version: BUILD_VERSION env var > git describe > fallback
+$version = getenv('BUILD_VERSION') ?: null;
+if (!$version) {
+    $version = trim((string) shell_exec('git describe --tags 2>/dev/null')) ?: 'dev';
+}
+
+echo "Building oce-import-codes.phar (version: $version)...\n";
 
 // Create build directory
 if (!is_dir($buildDir)) {
@@ -45,7 +51,7 @@ try {
     // Set metadata
     $phar->setMetadata([
         'name' => 'oce-import-codes',
-        'version' => '1.0.0',
+        'version' => $version,
         'created' => date('Y-m-d H:i:s')
     ]);
 


### PR DESCRIPTION
## Summary

- Chains build-phar workflow from release-please using `workflow_call` (fixes GITHUB_TOKEN not triggering other workflows)
- Adds `build-phar-on-release.yml` wrapper for manual `release: created` events
- Adds optional `tag_name` input to `workflow_dispatch` for attaching PHAR to existing releases
- Fixes checkout to use the tag ref when `tag_name` is provided
- Updates `build.php` to determine version from `BUILD_VERSION` env var or `git describe --tags`

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)