### PR TITLE
refactor: catch Throwable instead of Exception

### DIFF
--- a/bin/oce-import-codes
+++ b/bin/oce-import-codes
@@ -53,7 +53,7 @@ try {
     $application->add(new ImportCodesCommand());
     $application->setDefaultCommand('import', true);
     $application->run();
-} catch (Exception $e) {
+} catch (Throwable $e) {
     echo "Error: " . $e->getMessage() . "\n";
     exit(1);
 }

--- a/build.php
+++ b/build.php
@@ -80,7 +80,7 @@ try {
     echo "   Size: " . number_format(filesize($pharFile)) . " bytes\n";
     echo "   Usage: ./build/oce-import-codes.phar RXNORM /path/to/rxnorm.zip --openemr-path=/var/www/openemr\n";
 
-} catch (Exception $e) {
+} catch (Throwable $e) {
     echo "❌ Error building PHAR: " . $e->getMessage() . "\n";
     exit(1);
 }

--- a/src/Command/ImportCodesCommand.php
+++ b/src/Command/ImportCodesCommand.php
@@ -182,7 +182,7 @@ class ImportCodesCommand extends Command
         // Initialize OpenEMR connection
         try {
             $this->connector->initialize($openemrPath, $site);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logJson('error', 'Failed to initialize OpenEMR connection', ['error' => $e->getMessage()]);
             return Command::FAILURE;
         }
@@ -359,7 +359,7 @@ class ImportCodesCommand extends Command
 
             $this->logJson('success', 'Import completed successfully');
             return Command::SUCCESS;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logJson('error', 'Import failed', ['error' => $e->getMessage()]);
 
             // Cleanup on error
@@ -383,7 +383,7 @@ class ImportCodesCommand extends Command
         if (!$dryRun) {
             try {
                 $this->importer->import($codeType, $isWindows, $usExtension, $filePath);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // Check if this is a lock acquisition failure
                 if (str_contains($e->getMessage(), 'Failed to acquire database lock')) {
                     throw new CodeImportException("Import failed: " . $e->getMessage());

--- a/src/Service/CodeImporter.php
+++ b/src/Service/CodeImporter.php
@@ -243,7 +243,7 @@ class CodeImporter
             );
 
             return $result && $result['count'] > 0;
-        } catch (\Exception) {
+        } catch (\Throwable) {
             // If query fails, assume not loaded to be safe
             return false;
         }
@@ -412,7 +412,7 @@ class CodeImporter
 
         try {
             sqlQuery("SELECT RELEASE_LOCK(?)", [$this->currentLockName]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // Log error but don't throw exception during cleanup
             error_log("Warning: Failed to release database lock '{$this->currentLockName}': " . $e->getMessage());
         } finally {

--- a/src/Service/OpenEMRConnector.php
+++ b/src/Service/OpenEMRConnector.php
@@ -71,7 +71,7 @@ class OpenEMRConnector
             } else {
                 throw new OpenEMRConnectorException("OpenEMR database functions not available");
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw new OpenEMRConnectorException("OpenEMR database connection test failed: " . $e->getMessage());
         }
 

--- a/tests/E2E/RealVocabularyImportE2ETest.php
+++ b/tests/E2E/RealVocabularyImportE2ETest.php
@@ -64,7 +64,7 @@ class RealVocabularyImportE2ETest extends TestCase
         $this->connector = new OpenEMRConnector();
         try {
             $this->connector->initialize(self::OPENEMR_PATH, self::SITE);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->markTestSkipped('OpenEMR initialization failed: ' . $e->getMessage());
         }
     }
@@ -307,7 +307,7 @@ class RealVocabularyImportE2ETest extends TestCase
 
             $result = $this->connector->querySql("SELECT COUNT(*) as cnt FROM `{$tableName}`");
             return (int) ($result['cnt'] ?? 0);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             return 0;
         }
     }

--- a/tests/E2E/VocabularyImportE2ETest.php
+++ b/tests/E2E/VocabularyImportE2ETest.php
@@ -55,7 +55,7 @@ class VocabularyImportE2ETest extends TestCase
         $this->connector = new OpenEMRConnector();
         try {
             $this->connector->initialize(self::OPENEMR_PATH, self::SITE);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->markTestSkipped('OpenEMR initialization failed: ' . $e->getMessage());
         }
 

--- a/tests/Integration/ImportCodesIntegrationTest.php
+++ b/tests/Integration/ImportCodesIntegrationTest.php
@@ -58,7 +58,7 @@ class ImportCodesIntegrationTest extends TestCase
         try {
             $this->connector->initialize(self::OPENEMR_PATH, self::SITE);
             $this->openemrAvailable = true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->markTestSkipped('OpenEMR initialization failed: ' . $e->getMessage());
         }
     }


### PR DESCRIPTION
## Summary
- Replace `catch (Exception)` with `catch (Throwable)` across the codebase
- Ensures we catch both Exception and Error subclasses (TypeError, ArgumentCountError, etc.)

Closes #24

## Test plan
- [ ] Verify existing tests still pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)