### PR TITLE
fix(ImportCodesCommand): only check supported_external_dataloads for ICD types

### DIFF
--- a/src/Command/ImportCodesCommand.php
+++ b/src/Command/ImportCodesCommand.php
@@ -232,7 +232,11 @@ class ImportCodesCommand extends Command
             $this->logJson('warning', 'DRY RUN MODE - No database changes will be made');
         }
 
-        if (!$metadata['from_database']) {
+        // Only ICD code types use the supported_external_dataloads table for validation.
+        // Other types (RXNORM, SNOMED, CQM_VALUESET) are validated by filename patterns only.
+        $usesExternalDataloads = in_array($codeType, ['ICD9', 'ICD10'], true);
+
+        if ($usesExternalDataloads && !$metadata['from_database']) {
             if (!$allowUnsupported) {
                 $this->logJson('error', 'File not in supported_external_dataloads table', [
                     'filename' => basename($filePath),


### PR DESCRIPTION
## Summary

- Fix regression where RXNORM, SNOMED, and CQM_VALUESET files were incorrectly rejected as "not in supported_external_dataloads table"
- Only ICD9/ICD10 types use that table; other types validate via filename patterns only

## Test plan

- [ ] Import a CQM valueset file without `--allow-unsupported` - should succeed
- [ ] Import an ICD file not in the table without `--allow-unsupported` - should fail with suggestion
- [ ] Import an ICD file not in the table with `--allow-unsupported` - should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)

AI Disclosure: Yes