### PR TITLE
ci: migrate release-please to reusable workflow + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+# Monitor Composer dependencies
+- package-ecosystem: composer
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - dependencies
+  - composer
+  commit-message:
+    prefix: deps
+    include: scope
+
+# Monitor GitHub Actions
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - dependencies
+  - github-actions
+  commit-message:
+    prefix: deps
+    include: scope

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,67 +6,18 @@ on:
     - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+    uses: opencoreemr/github-workflows-public/.github/workflows/release-please-reusable.yml@0.0.1
+    permissions:
+      contents: write
+      pull-requests: write
 
-    - name: Run Release Please
-      id: release
-      uses: googleapis/release-please-action@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    # Convert lightweight tag to annotated tag
-    #
-    # Why this is needed:
-    # - Release-please creates releases via GitHub's release API, which creates lightweight tags
-    # - We require annotated tags because:
-    #   * git describe ignores lightweight tags by default (requires --tags flag)
-    #   * Lightweight tags are not copied into forks
-    #   * Annotated tags have proper metadata (creation date, tagger info, message)
-    #
-    # Why we do this after release creation:
-    # - We can't create the annotated tag before release-please runs because we don't know
-    #   the version number until release-please determines it from conventional commits
-    # - The GitHub release API will use an existing tag if present (per the target_commitish
-    #   parameter docs: "Unused if the Git tag already exists"), but release-please doesn't
-    #   provide a way to hook into the process between version determination and release creation
-    # - Using skip-github-release has known issues and breaks release-please's workflow
-    #   (see: https://github.com/googleapis/release-please/issues/1561)
-    #
-    # Race condition considerations:
-    # - There is a small window (milliseconds) between when the lightweight tag is created
-    #   and when we convert it to annotated where someone could fetch the lightweight tag
-    # - In practice, this risk is acceptable because:
-    #   * Most users interact with releases, not tags directly
-    #   * The window is extremely brief
-    #   * By the time manual tag fetches occur, the annotated version exists
-    #   * The GitHub release points to the correct commit regardless of tag type
-    - name: Convert to annotated tag
-      if: ${{ steps.release.outputs.release_created }}
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git fetch --tags
-        TAG_NAME="${{ steps.release.outputs.tag_name }}"
-        git tag -a -f -m "Release ${TAG_NAME}" "${TAG_NAME}" "${TAG_NAME}^{commit}"
-        git push -f origin "${TAG_NAME}"
-
-  # Build and attach PHAR to release
-  # This is called directly because release events from GITHUB_TOKEN
-  # don't trigger other workflows (GitHub security feature)
+  # Build and attach PHAR to release.
+  # Called directly because release events from GITHUB_TOKEN don't trigger
+  # other workflows (GitHub security feature).
   build-phar:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "php",
+  "annotated-tag": true,
   "packages": {
     ".": {
       "package-name": "oce-cli-import-codes",


### PR DESCRIPTION
## Summary

Two changes for this repo:

1. Replaces the inline release-please workflow with a thin caller of `opencoreemr/github-workflows-public/.github/workflows/release-please-reusable.yml@0.0.1`. Sets `"annotated-tag": true` in `release-please-config.json` so the openCoreEMR fork creates annotated tags directly. Removes the post-release "Convert to annotated tag" workaround. Preserves the `build-phar` sibling job, now gated on the reusable workflow's `release_created` output via `needs:`.
2. Adds `.github/dependabot.yml` monitoring composer and github-actions. This repo was previously missing dependabot config.

Smoke-tested on `openemr-phpstan-rules#25` — `0.9.1` was created as an annotated tag end-to-end via the reusable workflow.

## Test plan

- [x] actionlint clean
- [x] dependabot.yml valid YAML
- [ ] After merge, next release-please run produces an annotated tag AND triggers build-phar with the new tag_name