### PR TITLE
fix(ci): grant build-phar caller permission to fix release-please startup failure

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,8 @@ jobs:
   build-phar:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-phar.yml
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Fixes startup failure on the Release Please workflow ([run 25553201816](https://github.com/openCoreEMR/oce-cli-import-codes/actions/runs/25553201816)) introduced by #28.

The workflow has `permissions: {}` at the top level. The `build-phar` caller-job had no `permissions:` block of its own, so it inherited empty permissions. The local reusable workflow `build-phar.yml` declares `permissions: contents: write` at workflow level. GitHub rejects the call at startup because the caller cannot grant permissions it doesn't have, producing `STARTUP_FAILURE` with no logs.

Adding `permissions: contents: write` at the `build-phar` caller-job level gives it permission to grant to the called workflow.

The `release-please` job already has its own `permissions:` block, so it wasn't affected.

## Test plan

- [x] actionlint clean
- [ ] After merge: Release Please workflow no longer startup-fails on push to main
- [ ] When a real release goes out, build-phar fires and attaches the PHAR to the release
