### PR TITLE
ci: migrate to reusable PHP CI workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,18 +4,16 @@ on:
   push:
     branches:
     - main
+    paths:
+    - .github/workflows/**
+    - .github/actions/**
   pull_request:
     branches:
     - main
+    paths:
+    - .github/workflows/**
+    - .github/actions/**
 
 jobs:
   actionlint:
-    name: Lint GitHub Actions workflows
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Run actionlint
-      uses: rhysd/actionlint@v1.7.12
+    uses: openCoreEMR/github-workflows-public/.github/workflows/actionlint.yml@0.0.4

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -4,25 +4,21 @@ on:
   push:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-validate.yml
   pull_request:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-validate.yml
 
 jobs:
-  validate:
-    name: Validate composer.json
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        coverage: none
-        tools: composer:v2
-
-    - name: Validate composer.json
+  composer-validate:
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: Validate composer.json
       run: composer validate --strict
+      install-deps: false
+      php-version: '8.2'

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -4,25 +4,23 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - composer.json
+    - .github/workflows/php-syntax-check.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - composer.json
+    - .github/workflows/php-syntax-check.yml
 
 jobs:
-  syntax:
-    name: Check PHP Syntax
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        coverage: none
-
-    - name: Check PHP syntax
-      run: |
-        find src bin -name "*.php" -exec php -l {} \;
+  php-syntax-check:
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: PHP Syntax Check
+      run: composer php-lint
+      install-deps: false
+      php-version: '8.2'

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -4,37 +4,28 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - .phpcs.xml*
+    - phpcs.xml*
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpcs.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - .phpcs.xml*
+    - phpcs.xml*
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpcs.yml
 
 jobs:
   phpcs:
-    name: Run PHP CodeSniffer
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        extensions: json, zip, xml, simplexml
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run PHP CodeSniffer
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: Run PHP CodeSniffer
       run: composer phpcs
+      php-version: '8.2'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,37 +4,30 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - phpstan.neon
+    - phpstan.neon.dist
+    - phpstan-baseline.neon
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpstan.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - phpstan.neon
+    - phpstan.neon.dist
+    - phpstan-baseline.neon
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpstan.yml
 
 jobs:
   phpstan:
-    name: Run PHPStan
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        extensions: json, zip, xml, simplexml
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run PHPStan
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: Run PHPStan
       run: composer phpstan
+      php-version: '8.2'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,31 +10,7 @@ on:
 
 jobs:
   phpunit:
-    name: Run PHPUnit (Unit Tests)
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        extensions: json, zip, xml, simplexml
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run PHPUnit (unit tests only)
-      run: vendor/bin/phpunit --testsuite unit --testdox
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-tests.yml@0.0.4
+    with:
+      php-versions: '["8.2"]'
+      test-script: composer test:unit

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -4,37 +4,26 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - rector.php
+    - composer.json
+    - composer.lock
+    - .github/workflows/rector.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - rector.php
+    - composer.json
+    - composer.lock
+    - .github/workflows/rector.yml
 
 jobs:
   rector:
-    name: Run Rector (dry-run)
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.2'
-        extensions: json, zip, xml, simplexml
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run Rector (dry-run)
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: Run Rector (dry-run)
       run: composer rector
+      php-version: '8.2'


### PR DESCRIPTION
## Summary

Replace inlined CI workflows with thin callers of [`openCoreEMR/github-workflows-public@0.0.4`](https://github.com/openCoreEMR/github-workflows-public/releases/tag/0.0.4), matching the pattern established by openCoreEMR/oce-module-perspectives-scribe#8.

## Migrated

| Workflow | Reusable |
|---|---|
| `actionlint.yml` | `actionlint.yml` |
| `composer-validate.yml` | `php-composer-script.yml` (`composer validate --strict`, `install-deps: false`) |
| `php-syntax-check.yml` | `php-composer-script.yml` (`composer php-lint`, `install-deps: false`) |
| `phpcs.yml` | `php-composer-script.yml` (`composer phpcs`) |
| `phpstan.yml` | `php-composer-script.yml` (`composer phpstan`) |
| `phpunit.yml` | `php-tests.yml` (`php-versions: ["8.2"]`, `test-script: composer test:unit`) |
| `rector.yml` | `php-composer-script.yml` (`composer rector`) |

Every `php-composer-script` caller pins `php-version: '8.2'` (the reusable's default) so the file is self-documenting. Each caller also adds the `paths:` filter the github-workflows-public README recommends for that check.

## Stayed inlined

- `build-phar.yml`, `build-phar-on-release.yml` — CLI-specific PHAR build, no reusable counterpart yet.
- `release-please.yml` — already migrated separately.

## Notes

- The new `phpunit` caller preserves the unit-only behavior of the previous inlined workflow (`vendor/bin/phpunit --testsuite unit --testdox`); integration / e2e suites need a database and stay out of CI.
- A follow-up PR to add `composer-normalize`, `conventional-pr-title`, and `dclint` callers is planned separately.

## Test plan

- [ ] All reusable-backed checks run and pass on this PR