### PR TITLE
ci: add composer-normalize, conventional-pr-title, dclint; bind compose ports to localhost

### DIFF
--- a/.dclintrc.json
+++ b/.dclintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-duplicate-exported-ports": 0
+  }
+}

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -1,0 +1,23 @@
+name: Composer Normalize
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-normalize.yml
+  pull_request:
+    branches:
+    - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-normalize.yml
+
+jobs:
+  composer-normalize:
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
+    with:
+      name: Normalize composer.json (check)
+      run: composer normalize --dry-run
+      php-version: '8.2'

--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,9 @@
+name: Conventional PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  conventional-pr-title:
+    uses: openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml@0.0.4

--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -1,0 +1,25 @@
+name: dclint
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '**/compose.yml'
+    - '**/compose.yaml'
+    - '**/docker-compose*.yml'
+    - '**/docker-compose*.yaml'
+    - .github/workflows/dclint.yml
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '**/compose.yml'
+    - '**/compose.yaml'
+    - '**/docker-compose*.yml'
+    - '**/docker-compose*.yaml'
+    - .github/workflows/dclint.yml
+
+jobs:
+  dclint:
+    uses: openCoreEMR/github-workflows-public/.github/workflows/dclint.yml@0.0.4

--- a/compose.yml
+++ b/compose.yml
@@ -1,57 +1,76 @@
 # OpenEMR CLI Import Codes - Development Environment
 #
 # Extends OpenEMR's development-easy services with overrides:
-# - Random ports instead of fixed (8300, 9300, etc.)
+# - Random ports bound to 127.0.0.1 (avoid conflicts; never expose dev DB to LAN)
 # - CLI tool mounted into OpenEMR container
 # - PHPUnit services available via profiles
 
+name: oce-cli-import-codes
+
 services:
-  openemr:
+  couchdb:
+    ports: !override
+    - target: 5984
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
+    - target: 6984
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
     extends:
       file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
-      service: openemr
+      service: couchdb
+
+  mysql:
     ports: !override
-    - "80"
-    - "443"
+    - target: 3306
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: mysql
+
+  openemr:
     volumes:
     - .:/var/www/localhost/htdocs/openemr/oce-cli-import-codes:rw
+    ports: !override
+    - target: 80
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
+    - target: 443
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
     healthcheck:
       test: ["CMD", "curl", "-fsk", "https://localhost:443/"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 3m
-
-  mysql:
     extends:
       file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
-      service: mysql
-    ports: !override
-    - "3306"
-
-  phpmyadmin:
-    extends:
-      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
-      service: phpmyadmin
-    ports: !override
-    - "80"
-
-  couchdb:
-    extends:
-      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
-      service: couchdb
-    ports: !override
-    - "5984"
-    - "6984"
+      service: openemr
 
   openldap:
     extends:
       file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
       service: openldap
 
+  phpmyadmin:
+    ports: !override
+    - target: 80
+      host_ip: 127.0.0.1
+      protocol: tcp
+      mode: host
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: phpmyadmin
+
   # PHPUnit test runner
   phpunit:
-    profiles: [test]
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -59,10 +78,10 @@ services:
     - .:/app
     - /app/vendor
     command: vendor/bin/phpunit --testdox
+    profiles: [test]
 
   # PHPUnit with coverage
   phpunit-coverage:
-    profiles: [test]
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -70,9 +89,10 @@ services:
     - .:/app
     - /app/vendor
     - ./htmlcov:/app/htmlcov
-    command: vendor/bin/phpunit --coverage-html htmlcov --coverage-text
     environment:
       XDEBUG_MODE: coverage
+    command: vendor/bin/phpunit --coverage-html htmlcov --coverage-text
+    profiles: [test]
 
 volumes:
   databasevolume: {}


### PR DESCRIPTION
## Summary

Brings `oce-cli-import-codes` closer to parity with `oce-cli-manage-users` on the CI side, and incidentally fixes localhost-only port binding so dclint passes.

### New CI workflows

Callers of [`openCoreEMR/github-workflows-public@0.0.4`](https://github.com/openCoreEMR/github-workflows-public/releases/tag/0.0.4):

- **composer-normalize** — `composer normalize --dry-run` (`ergebnis/composer-normalize` is already in dev deps)
- **conventional-pr-title** — validates PR titles against the conventional-commits spec
- **dclint** — lints `compose.yml`

### compose.yml changes (required to make dclint pass)

- All published ports switched from short-form (`- "80"`) to **long-form with `host_ip: 127.0.0.1`**, so the dev MySQL/CouchDB/etc. no longer expose to `0.0.0.0`.
- Added required `name: oce-cli-import-codes`.
- Alphabetized services and reordered service keys per dclint expected layout.

**Behavior change:** anyone who relied on LAN access to the dev stack now needs an SSH tunnel or to set `host_ip: 0.0.0.0` explicitly.

### `.dclintrc.json`

Mirrors `oce-cli-manage-users`. Disables the `no-duplicate-exported-ports` rule, which false-positives on long-form ports without a `published` field (Docker assigns each service a distinct random host port; dclint reads the published key as empty string and treats them as duplicates).

### Not added (and why)

- **composer-require-checker** — needs both a `maglnet/composer-require-checker` dev dep and a `.composer-require-checker.json` config file. Add separately when ready.
- **hadolint** — no `Dockerfile*` in the repo today.

### Pre-existing issue uncovered (not in scope here)

The `phpunit` and `phpunit-coverage` services in `compose.yml` reference `dockerfile: Dockerfile.test`, which **does not exist** in the repo. Hidden today because both services are under `profiles: [test]` and only run on explicit invocation. Worth a follow-up to either add the Dockerfile or remove the phantom services.

The structural refactor (move `openemr/openemr` to `tools/openemr/` sub-vendor pattern, rewire `compose.yml` + `Taskfile.yml` + phpstan script) is deferred to a separate PR.

## Test plan

- [ ] All new CI checks pass on this PR (actionlint, composer-normalize, conventional-pr-title, dclint)
- [ ] Existing checks still pass (phpunit, phpcs, phpstan, rector, etc.)
- [ ] Local `task dev:start` still brings up the stack (ports now on 127.0.0.1)