### PR TITLE
chore: drop ghost phpunit and phpunit-coverage docker services

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -298,16 +298,6 @@ tasks:
     - task: test:integration
     - task: test:e2e
 
-  test:coverage:
-    desc: Run PHPUnit with coverage report
-    cmds:
-    - docker compose run --rm phpunit-coverage
-
-  test:docker:
-    desc: Run PHPUnit tests in Docker
-    cmds:
-    - docker compose run --rm phpunit
-
   # === Development Helpers ===
 
   composer:install:

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,6 @@
 # Extends OpenEMR's development-easy services with overrides:
 # - Random ports bound to 127.0.0.1 (avoid conflicts; never expose dev DB to LAN)
 # - CLI tool mounted into OpenEMR container
-# - PHPUnit services available via profiles
 
 name: oce-cli-import-codes
 
@@ -68,31 +67,6 @@ services:
     extends:
       file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
       service: phpmyadmin
-
-  # PHPUnit test runner
-  phpunit:
-    build:
-      context: .
-      dockerfile: Dockerfile.test
-    volumes:
-    - .:/app
-    - /app/vendor
-    command: vendor/bin/phpunit --testdox
-    profiles: [test]
-
-  # PHPUnit with coverage
-  phpunit-coverage:
-    build:
-      context: .
-      dockerfile: Dockerfile.test
-    volumes:
-    - .:/app
-    - /app/vendor
-    - ./htmlcov:/app/htmlcov
-    environment:
-      XDEBUG_MODE: coverage
-    command: vendor/bin/phpunit --coverage-html htmlcov --coverage-text
-    profiles: [test]
 
 volumes:
   databasevolume: {}


### PR DESCRIPTION
## Summary

Removes two compose services (`phpunit`, `phpunit-coverage`) and two Taskfile entries (`task test:docker`, `task test:coverage`) that have been broken since they were added — they reference `dockerfile: Dockerfile.test`, but that file has never existed in the repo. Hidden until now because the services live under `profiles: [test]` and only run on explicit invocation.

Spotted while reviewing #41.

## Why drop instead of fix

The functionality is covered elsewhere:

- `task test:unit` runs unit tests locally (`composer test:unit`)
- `task test:integration` / `task test:e2e` exec into the running `openemr` container (matches the existing pattern that already works)
- CI handles coverage via the [`openCoreEMR/github-workflows-public/php-tests.yml`](https://github.com/openCoreEMR/github-workflows-public/blob/main/.github/workflows/php-tests.yml) reusable when opted in via `coverage-php-version`

If local coverage HTML reports become a real need, add `Dockerfile.test` and reintroduce the services.

## Test plan

- [ ] `task --list` no longer shows `test:docker` / `test:coverage`
- [ ] `docker compose config` still validates
- [ ] dclint still passes (no new compose violations)